### PR TITLE
Update Pekko min version

### DIFF
--- a/src/main/scala/com/github/pjfanning/pekkobuild/PekkoDependency.scala
+++ b/src/main/scala/com/github/pjfanning/pekkobuild/PekkoDependency.scala
@@ -53,7 +53,7 @@ object PekkoDependency {
         }
     }
 
-  private val defaultPekkoVersion = System.getProperty("pekko.build.pekko.min.version", "1.0.0")
+  private val defaultPekkoVersion = System.getProperty("pekko.build.pekko.min.version", "1.0.2")
   val default                     = pekkoDependency(defaultPekkoVersion)
 
   lazy val snapshot10x   = Artifact(determineLatestSnapshot("1.0"), true)


### PR DESCRIPTION
As discussed on https://github.com/apache/incubator-pekko-http/issues/380 we should at lest use the latest patch version of Pekko 1.0.x