### PR TITLE
Add PekkoInlinePlugin

### DIFF
--- a/src/main/scala/com/github/pjfanning/pekkobuild/PekkoCorePlugin.scala
+++ b/src/main/scala/com/github/pjfanning/pekkobuild/PekkoCorePlugin.scala
@@ -1,0 +1,17 @@
+package com.github.pjfanning.pekkobuild
+
+import sbt._
+
+object PekkoCorePlugin extends AutoPlugin {
+
+  override def trigger: PluginTrigger = allRequirements
+
+  object autoImport extends PekkoCoreSettings
+
+  import autoImport._
+
+  override lazy val globalSettings = Seq(
+    pekkoCoreProject := false
+  )
+
+}

--- a/src/main/scala/com/github/pjfanning/pekkobuild/PekkoCoreSettings.scala
+++ b/src/main/scala/com/github/pjfanning/pekkobuild/PekkoCoreSettings.scala
@@ -1,0 +1,8 @@
+package com.github.pjfanning.pekkobuild
+
+import sbt._
+
+trait PekkoCoreSettings {
+  lazy val pekkoCoreProject: SettingKey[Boolean] = settingKey("Whether this is the core Pekko project or a Pekko" +
+    " module. Defaults to false")
+}

--- a/src/main/scala/com/github/pjfanning/pekkobuild/PekkoInlinePlugin.scala
+++ b/src/main/scala/com/github/pjfanning/pekkobuild/PekkoInlinePlugin.scala
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, derived from Akka.
+ */
+
+package com.github.pjfanning.pekkobuild
+
+import sbt.plugins.JvmPlugin
+import sbt._
+import sbt.Keys._
+
+object PekkoInlinePlugin extends AutoPlugin {
+  override def trigger: PluginTrigger = allRequirements
+
+  override def requires: Plugins = JvmPlugin
+
+  object autoImport extends PekkoInlineSettings
+
+  import autoImport._
+
+  private def flagsForScala2(coreProject: Boolean) = {
+    val baseInlineFlags = Seq(
+      "-opt-inline-from:<sources>",
+      "-opt:l:inline"
+    )
+
+    if (coreProject)
+      baseInlineFlags ++ Seq(
+        // Since the Pekko core project doesn't allow for mixing of different versions,
+        // i.e. you cannot mix pekko-actor 1.0.0 with pekko-streams 1.0.1 at runtime
+        // its safe to do inter sbt project inlining.
+        "-opt-inline-from:org.apache.pekko.**"
+      )
+    else baseInlineFlags ++ Seq(
+      // These are safe to inline even across modules since they are
+      // wrappers for cross compilation that is stable within Pekko core.
+      "-opt-inline-from:org.apache.pekko.dispatch.internal.SameThreadExecutionContext**",
+      "-opt-inline-from:org.apache.pekko.util.OptionConverters**",
+      "-opt-inline-from:org.apache.pekko.util.FutureConverters**",
+      "-opt-inline-from:org.apache.pekko.util.FunctionConverters**",
+      "-opt-inline-from:org.apache.pekko.util.PartialFunction**",
+      "-opt-inline-from:org.apache.pekko.util.JavaDurationConverters**"
+    )
+  }
+
+  // Optimizer not yet available for Scala3, see https://docs.scala-lang.org/overviews/compiler-options/optimizer.html
+  private val flagsForScala3 = Seq()
+
+  override lazy val globalSettings = Seq(
+    pekkoInlineEnabled := !sys.props.contains("pekko.no.inline"),
+    pekkoInlineCoreProject := false
+  )
+
+  override lazy val projectSettings = Seq(Compile / scalacOptions ++= {
+    if (pekkoInlineEnabled.value) {
+      CrossVersion.partialVersion(scalaVersion.value) match {
+        case Some((2, n)) if n == 12 | n == 13 =>
+          flagsForScala2(pekkoInlineCoreProject.value)
+        case Some((3, _)) =>
+          flagsForScala3
+      }
+    } else Seq.empty
+  })
+}

--- a/src/main/scala/com/github/pjfanning/pekkobuild/PekkoInlinePlugin.scala
+++ b/src/main/scala/com/github/pjfanning/pekkobuild/PekkoInlinePlugin.scala
@@ -9,6 +9,7 @@
 
 package com.github.pjfanning.pekkobuild
 
+import com.github.pjfanning.pekkobuild.PekkoCorePlugin.autoImport.pekkoCoreProject
 import sbt.plugins.JvmPlugin
 import sbt._
 import sbt.Keys._
@@ -16,7 +17,7 @@ import sbt.Keys._
 object PekkoInlinePlugin extends AutoPlugin {
   override def trigger: PluginTrigger = allRequirements
 
-  override def requires: Plugins = JvmPlugin
+  override def requires: Plugins = JvmPlugin && PekkoCorePlugin
 
   object autoImport extends PekkoInlineSettings
 
@@ -51,15 +52,14 @@ object PekkoInlinePlugin extends AutoPlugin {
   private val flagsForScala3 = Seq()
 
   override lazy val globalSettings = Seq(
-    pekkoInlineEnabled := !sys.props.contains("pekko.no.inline"),
-    pekkoInlineCoreProject := false
+    pekkoInlineEnabled := !sys.props.contains("pekko.no.inline")
   )
 
   override lazy val projectSettings = Seq(Compile / scalacOptions ++= {
     if (pekkoInlineEnabled.value) {
       CrossVersion.partialVersion(scalaVersion.value) match {
         case Some((2, n)) if n == 12 | n == 13 =>
-          flagsForScala2(pekkoInlineCoreProject.value)
+          flagsForScala2(pekkoCoreProject.value)
         case Some((3, _)) =>
           flagsForScala3
       }

--- a/src/main/scala/com/github/pjfanning/pekkobuild/PekkoInlineSettings.scala
+++ b/src/main/scala/com/github/pjfanning/pekkobuild/PekkoInlineSettings.scala
@@ -5,6 +5,4 @@ import sbt.{SettingKey, settingKey}
 trait PekkoInlineSettings {
   lazy val pekkoInlineEnabled: SettingKey[Boolean] = settingKey("Whether to enable the Scala 2 inliner for Pekko modules." +
     "Defaults to pekko.no.inline property")
-  lazy val pekkoInlineCoreProject: SettingKey[Boolean] = settingKey("Whether this is the core Pekko project or a Pekko module " +
-    "since the core Pekko project has different inline settings. Defaults to false")
 }

--- a/src/main/scala/com/github/pjfanning/pekkobuild/PekkoInlineSettings.scala
+++ b/src/main/scala/com/github/pjfanning/pekkobuild/PekkoInlineSettings.scala
@@ -1,0 +1,10 @@
+package com.github.pjfanning.pekkobuild
+
+import sbt.{SettingKey, settingKey}
+
+trait PekkoInlineSettings {
+  lazy val pekkoInlineEnabled: SettingKey[Boolean] = settingKey("Whether to enable the Scala 2 inliner for Pekko modules." +
+    "Defaults to pekko.no.inline property")
+  lazy val pekkoInlineCoreProject: SettingKey[Boolean] = settingKey("Whether this is the core Pekko project or a Pekko module " +
+    "since the core Pekko project has different inline settings. Defaults to false")
+}


### PR DESCRIPTION
This PR automatically enables the Scala 2 inliner for Pekkos modules. Unlike pekko core's [`PekkoInlinePlugin`](https://github.com/apache/incubator-pekko/blob/main/project/PekkoInlinePlugin.scala), this version **_ONLY_** does inlining that is considered safe, i.e. `"-opt-inline-from:<sources>"` which only inlines sources internal within the sbt module itself (i.e. never inlines code from outside the sbt module) and the various `org.apache.pekko.util`/`org.apache.pekko.dispatch` functions which are guaranteed not to change (hence safe to inline)

Note that even though this plugin is automatically enabled, in exceptional cases you can disable this plugin using `DisablePlugin(PekkoInlinePlugin)` on the sbt module.

Lastly, it is intended that this inliner should only be used for the 1.1.x branches of the various Pekko modules. I can't recall on the top of my head if we started using the `sbt-pekko-build` for Pekko projects that are still sitting on 1.0.x. If this is the case then another check needs to be added to make sure that the inliner is only enabled if the version of the module is 1.1.0 or higher, @pjfanning can you confirm/deny this?