### PR TITLE
Add scalafmt GitHub action

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,23 @@
+name: Scalafmt
+
+permissions: read-all
+
+on:
+  pull_request:
+    branches: ['**']
+
+jobs:
+  build:
+    name: Code is formatted
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout current branch (full)
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Check project is formatted
+        uses: jrouly/scalafmt-native-action@v3
+        with:
+          arguments: '--list --mode diff-ref=origin/main'

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version = 3.7.11
+version = 3.7.17
 runner.dialect = scala213
 preset = default
 align.preset = more

--- a/src/main/scala/com/github/pjfanning/pekkobuild/PekkoCoreSettings.scala
+++ b/src/main/scala/com/github/pjfanning/pekkobuild/PekkoCoreSettings.scala
@@ -3,6 +3,8 @@ package com.github.pjfanning.pekkobuild
 import sbt._
 
 trait PekkoCoreSettings {
-  lazy val pekkoCoreProject: SettingKey[Boolean] = settingKey("Whether this is the core Pekko project or a Pekko" +
-    " module. Defaults to false")
+  lazy val pekkoCoreProject: SettingKey[Boolean] = settingKey(
+    "Whether this is the core Pekko project or a Pekko" +
+      " module. Defaults to false"
+  )
 }

--- a/src/main/scala/com/github/pjfanning/pekkobuild/PekkoDependency.scala
+++ b/src/main/scala/com/github/pjfanning/pekkobuild/PekkoDependency.scala
@@ -20,10 +20,10 @@ trait PekkoDependency extends VersionRegex {
 
   private lazy val moduleName = module match {
     case Some(mName) => s"pekko.$mName"
-    case None => "pekko" // Main pekko module
+    case None        => "pekko" // Main pekko module
   }
 
-  def dependency(defaultVersion: String): Dependency = {
+  def dependency(defaultVersion: String): Dependency =
     Option(System.getProperty(s"$moduleName.sources")) match {
       case Some(pekkoSources) =>
         Sources(pekkoSources)
@@ -36,13 +36,12 @@ trait PekkoDependency extends VersionRegex {
           case Some(other)            => Artifact(other, isSnapshot = true)
         }
     }
-  }
 
   private lazy val defaultVersion = System.getProperty(s"pekko.build.$moduleName.min.version", currentVersion)
   lazy val default: Dependency    = dependency(defaultVersion)
 
-  lazy val snapshot10x: Artifact = Artifact(determineLatestSnapshot(minVersion), isSnapshot = true)
-  lazy val snapshotMain: Artifact = Artifact(determineLatestSnapshot(), isSnapshot = true)
+  lazy val snapshot10x: Artifact   = Artifact(determineLatestSnapshot(minVersion), isSnapshot = true)
+  lazy val snapshotMain: Artifact  = Artifact(determineLatestSnapshot(), isSnapshot = true)
   lazy val latestRelease: Artifact = Artifact(determineLatestRelease(), isSnapshot = false)
 
   lazy val version: String = default match {

--- a/src/main/scala/com/github/pjfanning/pekkobuild/PekkoInlinePlugin.scala
+++ b/src/main/scala/com/github/pjfanning/pekkobuild/PekkoInlinePlugin.scala
@@ -36,16 +36,17 @@ object PekkoInlinePlugin extends AutoPlugin {
         // its safe to do inter sbt project inlining.
         "-opt-inline-from:org.apache.pekko.**"
       )
-    else baseInlineFlags ++ Seq(
-      // These are safe to inline even across modules since they are
-      // wrappers for cross compilation that is stable within Pekko core.
-      "-opt-inline-from:org.apache.pekko.dispatch.internal.SameThreadExecutionContext**",
-      "-opt-inline-from:org.apache.pekko.util.OptionConverters**",
-      "-opt-inline-from:org.apache.pekko.util.FutureConverters**",
-      "-opt-inline-from:org.apache.pekko.util.FunctionConverters**",
-      "-opt-inline-from:org.apache.pekko.util.PartialFunction**",
-      "-opt-inline-from:org.apache.pekko.util.JavaDurationConverters**"
-    )
+    else
+      baseInlineFlags ++ Seq(
+        // These are safe to inline even across modules since they are
+        // wrappers for cross compilation that is stable within Pekko core.
+        "-opt-inline-from:org.apache.pekko.dispatch.internal.SameThreadExecutionContext**",
+        "-opt-inline-from:org.apache.pekko.util.OptionConverters**",
+        "-opt-inline-from:org.apache.pekko.util.FutureConverters**",
+        "-opt-inline-from:org.apache.pekko.util.FunctionConverters**",
+        "-opt-inline-from:org.apache.pekko.util.PartialFunction**",
+        "-opt-inline-from:org.apache.pekko.util.JavaDurationConverters**"
+      )
   }
 
   // Optimizer not yet available for Scala3, see https://docs.scala-lang.org/overviews/compiler-options/optimizer.html

--- a/src/main/scala/com/github/pjfanning/pekkobuild/PekkoInlineSettings.scala
+++ b/src/main/scala/com/github/pjfanning/pekkobuild/PekkoInlineSettings.scala
@@ -3,6 +3,8 @@ package com.github.pjfanning.pekkobuild
 import sbt.{SettingKey, settingKey}
 
 trait PekkoInlineSettings {
-  lazy val pekkoInlineEnabled: SettingKey[Boolean] = settingKey("Whether to enable the Scala 2 inliner for Pekko modules." +
-    "Defaults to pekko.no.inline property")
+  lazy val pekkoInlineEnabled: SettingKey[Boolean] = settingKey(
+    "Whether to enable the Scala 2 inliner for Pekko modules." +
+      "Defaults to pekko.no.inline property"
+  )
 }

--- a/src/main/scala/com/github/pjfanning/pekkobuild/VersionRegex.scala
+++ b/src/main/scala/com/github/pjfanning/pekkobuild/VersionRegex.scala
@@ -22,9 +22,11 @@ trait VersionRegex {
   // `_2.13` is assumed
   protected val checkProject: String
 
-  protected def determineLatestSnapshot(prefix: String = ""): String = determineLatestVersion(useSnapshots = true, prefix)
+  protected def determineLatestSnapshot(prefix: String = ""): String =
+    determineLatestVersion(useSnapshots = true, prefix)
 
-  protected def determineLatestRelease(prefix: String = ""): String = determineLatestVersion(useSnapshots = false, prefix)
+  protected def determineLatestRelease(prefix: String = ""): String =
+    determineLatestVersion(useSnapshots = false, prefix)
 
   protected def determineLatestVersion(useSnapshots: Boolean, prefix: String): String = {
     import sbt.librarymanagement.Http.http

--- a/src/main/scala/com/github/pjfanning/pekkobuild/package.scala
+++ b/src/main/scala/com/github/pjfanning/pekkobuild/package.scala
@@ -21,9 +21,7 @@ package object pekkobuild {
   implicit class RichProject(project: Project) {
 
     /** Adds either a source or a binary dependency, depending on whether the above settings are set */
-    def addPekkoModuleDependency(module: String,
-                                 config: String = "",
-                                 pekko: Dependency): Project =
+    def addPekkoModuleDependency(module: String, config: String = "", pekko: Dependency): Project =
       pekko match {
         case Sources(sources, _) =>
           val moduleRef = ProjectRef(uri(sources), module)

--- a/src/test/scala/com/github/pjfanning/pekkobuild/PekkoCoreDependency.scala
+++ b/src/test/scala/com/github/pjfanning/pekkobuild/PekkoCoreDependency.scala
@@ -18,7 +18,7 @@
 package com.github.pjfanning.pekkobuild
 
 object PekkoCoreDependency extends PekkoDependency {
-  override val checkProject: String = "pekko-cluster-sharding-typed"
+  override val checkProject: String   = "pekko-cluster-sharding-typed"
   override val module: Option[String] = None
   override val currentVersion: String = "1.0.2"
 }

--- a/src/test/scala/com/github/pjfanning/pekkobuild/PekkoHttpDependency.scala
+++ b/src/test/scala/com/github/pjfanning/pekkobuild/PekkoHttpDependency.scala
@@ -18,7 +18,7 @@
 package com.github.pjfanning.pekkobuild
 
 object PekkoHttpDependency extends PekkoDependency {
-  override val checkProject: String = "pekko-http-testkit"
+  override val checkProject: String   = "pekko-http-testkit"
   override val module: Option[String] = Some("http")
   override val currentVersion: String = "1.0.0"
 }


### PR DESCRIPTION
I noticed that even though the project has scalafmt added, its not being checked and hence the codebase is currently out of sync with the formatter.

This PR adds the scalafmt github action and also applies `scalafmt` so the whole codebase is formatted. 

@pjfanning I would merge this PR with "Rebase + merge" in order to not lose the "Apply scalafmt" commit so it can be added to a `.git-blame-ignore-revs` file which I will do in a future PR. Also once merged you can add scalafmt github action to the github branch check so we don't accidentally merge unformatted code again.