### PR TITLE
Include sbt-apache-sonatype

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,8 @@ developers := List(
   Developer(id = "pjfanning", name = "PJ Fanning", email = "", url = url("https://github.com/pjfanning"))
 )
 
-addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.1.3")
+addSbtPlugin("com.typesafe"   % "sbt-mima-plugin"     % "1.1.3")
+addSbtPlugin("org.mdedetrich" % "sbt-apache-sonatype" % "0.1.11")
 
 ThisBuild / githubWorkflowBuild := Seq(WorkflowStep.Sbt(List("test")))
 ThisBuild / githubWorkflowTargetTags ++= Seq("v*")

--- a/src/main/scala/com/github/pjfanning/pekkobuild/PekkoCorePlugin.scala
+++ b/src/main/scala/com/github/pjfanning/pekkobuild/PekkoCorePlugin.scala
@@ -1,10 +1,13 @@
 package com.github.pjfanning.pekkobuild
 
+import org.mdedetrich.apache.sonatype.ApacheSonatypePlugin
+import org.mdedetrich.apache.sonatype.ApacheSonatypePlugin.autoImport.apacheSonatypeProjectProfile
 import sbt._
 
 object PekkoCorePlugin extends AutoPlugin {
 
-  override def trigger: PluginTrigger = allRequirements
+  override lazy val trigger: PluginTrigger = allRequirements
+  override lazy val requires: Plugins      = ApacheSonatypePlugin
 
   object autoImport extends PekkoCoreSettings
 
@@ -12,6 +15,10 @@ object PekkoCorePlugin extends AutoPlugin {
 
   override lazy val globalSettings = Seq(
     pekkoCoreProject := false
+  )
+
+  override lazy val buildSettings = Seq(
+    apacheSonatypeProjectProfile := "pekko"
   )
 
 }

--- a/src/main/scala/com/github/pjfanning/pekkobuild/PekkoInlinePlugin.scala
+++ b/src/main/scala/com/github/pjfanning/pekkobuild/PekkoInlinePlugin.scala
@@ -15,9 +15,9 @@ import sbt._
 import sbt.Keys._
 
 object PekkoInlinePlugin extends AutoPlugin {
-  override def trigger: PluginTrigger = allRequirements
+  override lazy val trigger: PluginTrigger = allRequirements
 
-  override def requires: Plugins = JvmPlugin && PekkoCorePlugin
+  override lazy val requires: Plugins = JvmPlugin && PekkoCorePlugin
 
   object autoImport extends PekkoInlineSettings
 


### PR DESCRIPTION
For context see https://github.com/apache/incubator-pekko/pull/1034#issuecomment-1907115232. This PR means that we no longer have to bring in sbt-apache-sonatype since it will be brought in by sbt-pekko-build. Furthermore it already sets the `apacheSonatypeProjectProfile` to "pekko" which removes some boilerplate.

I also set some zero arg def's to lazy val's