### PR TITLE
Remove sonatypeRelease commands

### DIFF
--- a/src/main/scala/com/github/pjfanning/pekkobuild/PekkoCorePlugin.scala
+++ b/src/main/scala/com/github/pjfanning/pekkobuild/PekkoCorePlugin.scala
@@ -3,6 +3,7 @@ package com.github.pjfanning.pekkobuild
 import org.mdedetrich.apache.sonatype.ApacheSonatypePlugin
 import org.mdedetrich.apache.sonatype.ApacheSonatypePlugin.autoImport.apacheSonatypeProjectProfile
 import sbt._
+import sbt.Keys._
 
 object PekkoCorePlugin extends AutoPlugin {
 
@@ -18,7 +19,14 @@ object PekkoCorePlugin extends AutoPlugin {
   )
 
   override lazy val buildSettings = Seq(
-    apacheSonatypeProjectProfile := "pekko"
+    apacheSonatypeProjectProfile := "pekko",
+    // So we don't accidentally release locally,
+    // see https://github.com/apache/incubator-pekko-site/wiki/Pekko-Release-Process#deploy-the-jars-to-apache-maven-repository-staging
+    LocalRootProject / commands := (LocalRootProject / commands).value.filterNot { command =>
+      command.nameOption.exists { name =>
+        name.contains("sonatypeRelease") || name.contains("sonatypeBundleRelease")
+      }
+    }
   )
 
 }


### PR DESCRIPTION
So we can remove the https://github.com/apache/incubator-pekko/blob/main/build.sbt#L20-L24 boilerplate from our projects