### PR TITLE
Capture build scans on ge.apache.org to benefit from deep build insights

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Copies 2 features from different Pekko repos that are useful to share around our
 * Mima builds on sbt-mima-plugin and provides support for looking up exclude files in `mima-filters` directories.
     - see https://github.com/apache/incubator-pekko/blob/main/CONTRIBUTING.md#binary-compatibility
  
-v0.3.0 and above also containe an autoplugin that enables Scala compile inling (Scala 2 only). This behaviour cannot be enabled on any Pekko 1.0.x module.
+v0.3.0 and above also contains an autoplugin that enables Scala compile inlining (Scala 2 only). This behaviour cannot be enabled on any Pekko 1.0.x module.
 
 The default is:
 ```
@@ -28,4 +28,3 @@ This is usable as is in v0.2.x but in v0.3.0 and above, you need to add a file t
 * `-Dpekko.build.pekko.version=latest-release` will find latest release regardless of version number (December 2023 - this evals to `1.0.2`)
 * `-Dpekko.build.pekko.version=main` will find latest snapshot for `main` branch (December 2023 - this evals to `1.1.0-M0+...-SNAPSHOT`)
 * `-Dpekko.build.pekko.version=1.0.x` will find latest snapshot for `1.0.x` branch
-

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # sbt-pekko-build
 
-Copies 2 features from different Pekko repos that are useful to share around our other Pekko repos.
+Copies 3 features from different Pekko repos that are useful to share around our other Pekko repos.
 
 * PekkoDependency has code to get latest release and snapshot versions for core Pekko jars
 * Mima builds on sbt-mima-plugin and provides support for looking up exclude files in `mima-filters` directories.
     - see https://github.com/apache/incubator-pekko/blob/main/CONTRIBUTING.md#binary-compatibility
+* Enables automatic Build Scan® publishing to [Apache Develocity](https://ge.apache.org) instance.
+    - see https://docs.gradle.com/develocity/sbt-plugin/
  
 v0.3.0 and above also contains an autoplugin that enables Scala compile inlining (Scala 2 only). This behaviour cannot be enabled on any Pekko 1.0.x module.
 

--- a/build.sbt
+++ b/build.sbt
@@ -45,7 +45,7 @@ scalacOptions ++= {
 ThisBuild / scalaVersion := "2.12.18"
 
 libraryDependencies ++= Seq(
-  "org.scalatest" %% "scalatest" % "3.2.17" % Test
+  "org.scalatest" %% "scalatest" % "3.2.18" % Test
 )
 
 homepage := Some(url("https://github.com/pjfanning/sbt-pekko-build"))
@@ -58,6 +58,7 @@ developers := List(
 
 addSbtPlugin("com.typesafe"   % "sbt-mima-plugin"     % "1.1.3")
 addSbtPlugin("org.mdedetrich" % "sbt-apache-sonatype" % "0.1.11")
+addSbtPlugin("com.gradle"     % "sbt-develocity"      % "1.0.1")
 
 ThisBuild / githubWorkflowBuild := Seq(WorkflowStep.Sbt(List("test")))
 ThisBuild / githubWorkflowTargetTags ++= Seq("v*")

--- a/src/main/scala/com/github/pjfanning/pekkobuild/PekkoDevelocityPlugin.scala
+++ b/src/main/scala/com/github/pjfanning/pekkobuild/PekkoDevelocityPlugin.scala
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.github.pjfanning.pekkobuild
+
+import com.gradle.develocity.agent.sbt.DevelocityPlugin
+import com.gradle.develocity.agent.sbt.DevelocityPlugin.autoImport.{develocityConfiguration, ProjectId, Publishing}
+import sbt.{AutoPlugin, Plugins, PluginTrigger, Setting}
+
+import java.net.URI
+
+object PekkoDevelocityPlugin extends AutoPlugin {
+
+  private val ApacheDevelocityUrl   = URI.create("https://ge.apache.org").toURL
+  private val PekkoProjectId        = ProjectId("pekko")
+  private val ObfuscatedIPv4Address = "0.0.0.0"
+
+  private lazy val isCI = sys.env.get("CI").exists(_.toBoolean)
+
+  override lazy val trigger: PluginTrigger = allRequirements
+  override lazy val requires: Plugins      = DevelocityPlugin
+
+  override lazy val buildSettings: Seq[Setting[_]] = Seq(
+    develocityConfiguration := {
+      val original = develocityConfiguration.value
+      original
+        .withProjectId(PekkoProjectId)
+        .withServer(
+          original.server
+            .withUrl(Some(ApacheDevelocityUrl))
+            .withAllowUntrusted(false)
+        )
+        .withBuildScan(
+          original.buildScan
+            .withPublishing(Publishing.onlyIf(_.authenticated))
+            .withBackgroundUpload(!isCI)
+            .withObfuscation(
+              original.buildScan.obfuscation
+                .withIpAddresses(_.map(_ => ObfuscatedIPv4Address))
+            )
+        )
+    }
+  )
+}

--- a/src/main/scala/com/github/pjfanning/pekkobuild/PekkoDevelocityPlugin.scala
+++ b/src/main/scala/com/github/pjfanning/pekkobuild/PekkoDevelocityPlugin.scala
@@ -25,6 +25,7 @@ import com.gradle.develocity.agent.sbt.DevelocityPlugin.autoImport.{
   Publishing
 }
 import sbt.{AutoPlugin, Plugins, PluginTrigger, Setting}
+import sbt.Keys.insideCI
 
 import java.net.URI
 
@@ -34,13 +35,13 @@ object PekkoDevelocityPlugin extends AutoPlugin {
   private val PekkoProjectId        = ProjectId("pekko")
   private val ObfuscatedIPv4Address = "0.0.0.0"
 
-  private lazy val isCI = sys.env.get("CI").exists(_.toBoolean)
-
   override lazy val trigger: PluginTrigger = allRequirements
   override lazy val requires: Plugins      = DevelocityPlugin
 
   override lazy val buildSettings: Seq[Setting[_]] = Seq(
     develocityConfiguration := {
+      val isCI = insideCI.value
+
       val original = develocityConfiguration.value
       val apacheDevelocityConfiguration =
         original
@@ -64,7 +65,7 @@ object PekkoDevelocityPlugin extends AutoPlugin {
           .withTestRetryConfiguration(
             original.testRetryConfiguration
               .withMaxRetries(1)
-              .withFlakyTestPolicy(FlakyTestPolicy.Fail)
+              .withFlakyTestPolicy(FlakyTestPolicy.Fail) // preserve the original build outcome in case of flaky tests
           )
       } else apacheDevelocityConfiguration
     }


### PR DESCRIPTION
This PR adds a new auto-plugin that configures publishing of a build scan for every CI build on Jenkins and GitHub Actions and for every local build from an authenticated Apache committer. The build will not fail if publishing fails.

All projects in the Pekko ecosystem will benefit from build insights once this PR is accepted and a new version of `sbt-pekko-build` plugin is applied.

The build scans of the Apache Pekko projects are published to the Develocity instance at [ge.apache.org](https://ge.apache.org/), hosted by the Apache Software Foundation and run in partnership between the ASF and Gradle. This Develocity instance has all features and extensions enabled and is freely available for use by the Apache Pekko projects and all other Apache projects.

This pull request enhances the functionality of publishing build scans to the publicly available [scans.gradle.com](https://scans.gradle.com/) by instead publishing build scans to [ge.apache.org](https://ge.apache.org/). On this Develocity instance, Apache Pekko will have access not only to all of the published build scans but other aggregate data features such as:

Dashboards to view all historical build scans, along with performance trends over time
Build failure analytics for enhanced investigation and diagnosis of build failures
Test failure analytics to better understand trends and causes around slow, failing, and flaky tests
If interested in exploring a fully populated Develocity instance, please explore the builds already connected to [ge.apache.org](https://ge.apache.org/), the [Spring project’s instance](https://ge.spring.io/scans?search.relativeStartTime=P28D&search.timeZoneId=Europe/Zurich), or any number of other [OSS projects](https://gradle.com/enterprise-customers/oss-projects/) for which we sponsor instances of Develocity.

Please let me know if there are any questions about the value of Develocity or the changes in this pull request and I’d be happy to address them.