### PR TITLE
sbt-apache-sonatype 0.1.12

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -57,7 +57,7 @@ developers := List(
 )
 
 addSbtPlugin("com.typesafe"   % "sbt-mima-plugin"     % "1.1.4")
-addSbtPlugin("org.mdedetrich" % "sbt-apache-sonatype" % "0.1.11")
+addSbtPlugin("org.mdedetrich" % "sbt-apache-sonatype" % "0.1.12")
 
 ThisBuild / githubWorkflowBuild := Seq(WorkflowStep.Sbt(List("test")))
 ThisBuild / githubWorkflowTargetTags ++= Seq("v*")


### PR DESCRIPTION
See https://github.com/apache/pekko/pull/1497

This upgrade means that you should use sbt 1.10.2 when you upgrade to latest sbt-pekko-build release.